### PR TITLE
Copy then remove file

### DIFF
--- a/src/ffmpeg/mod.rs
+++ b/src/ffmpeg/mod.rs
@@ -147,7 +147,8 @@ impl FFmpegProcessor {
         }
 
         // Move the file from work folder to final location
-        tokio::fs::rename(&work_output_path, &final_output_path).await?;
+        tokio::fs::copy(&work_output_path, &final_output_path).await?;
+        tokio::fs::remove_file(&work_output_path).await?;
 
         info!(
             "📁 Moved completed file: {:?} -> {:?}",


### PR DESCRIPTION
The fs:rename was unable to move files across disks and we must assume that moving across disks will be the default behavior